### PR TITLE
Make touch events passive.

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -171,15 +171,15 @@ function createCamera(element, options) {
     var xy = mouseOffset(ev.changedTouches[0], element)
     handleInteraction(0, xy[0], xy[1], lastMods)
     handleInteraction(1, xy[0], xy[1], lastMods)
-  })
+  }, {passive: true})
   element.addEventListener('touchmove', function (ev) {
     var xy = mouseOffset(ev.changedTouches[0], element)
     handleInteraction(1, xy[0], xy[1], lastMods)
-  })
+  }, {passive: true})
   element.addEventListener('touchend', function (ev) {
     var xy = mouseOffset(ev.changedTouches[0], element)
     handleInteraction(0, lastX, lastY, lastMods)
-  })
+  }, {passive: true})
 
   function handleInteraction (buttons, x, y, mods) {
     var scale = 1.0 / element.clientHeight


### PR DESCRIPTION
I observed a bunch of warnings due to the new [passive event API](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md), and this change fixes those warnings. Could add feature detection here too, but I'm not sure how critical this is given the distribution of this feature (in Chrome 51, Firefox 49).