### PR TITLE
Prevent page scrolling

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -7,6 +7,7 @@ var createView  = require('3d-view')
 var mouseChange = require('mouse-change')
 var mouseWheel  = require('mouse-wheel')
 var mouseOffset = require('mouse-event-offset')
+var hasPassive  = require('has-passive-events')
 
 function createCamera(element, options) {
   element = element || document.body
@@ -171,15 +172,23 @@ function createCamera(element, options) {
     var xy = mouseOffset(ev.changedTouches[0], element)
     handleInteraction(0, xy[0], xy[1], lastMods)
     handleInteraction(1, xy[0], xy[1], lastMods)
-  })
+
+    ev.preventDefault()
+  }, hasPassive ? {passive: false} : false)
+
   element.addEventListener('touchmove', function (ev) {
     var xy = mouseOffset(ev.changedTouches[0], element)
     handleInteraction(1, xy[0], xy[1], lastMods)
-  })
+
+    ev.preventDefault()
+  }, hasPassive ? {passive: false} : false)
+
   element.addEventListener('touchend', function (ev) {
     var xy = mouseOffset(ev.changedTouches[0], element)
     handleInteraction(0, lastX, lastY, lastMods)
-  })
+
+    ev.preventDefault()
+  }, hasPassive ? {passive: false} : false)
 
   function handleInteraction (buttons, x, y, mods) {
     var scale = 1.0 / element.clientHeight

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "3d-view": "^2.0.0",
+    "has-passive-events": "^1.0.0",
     "mouse-change": "^1.1.1",
     "mouse-event-offset": "^3.0.2",
     "mouse-wheel": "^1.0.2",


### PR DESCRIPTION
Covers #3.

In chrome we see warnings:
![image](https://user-images.githubusercontent.com/300067/35456880-00b5ca20-02a5-11e8-98e6-30d56562a8ac.png)

This PR disables them, as well as prevents default events in order to avoid page scroll while panning the element.

@mikolalysenko please look if that is desirable behavior or we're better off just muting logging.
